### PR TITLE
Fixed tree.root(newRoot) bug

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -166,7 +166,7 @@
       return this.parentnode;
     } else {
       if (!this._edgetoparent) {
-        this._edgetoparent = new Edge(this.jsav, this, newParent, options);
+        this._setEdgeToParent(new Edge(this.jsav, this, newParent, options));
       }
       return this._setparent(newParent, options);
     }


### PR DESCRIPTION
tree.root(newRoot) now also works for binary trees. Fixed a bug which caused an error for the layout function when changing the root node.
