### PR TITLE
Fixed attributes for new and old root in treeproto._setrootnode

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -43,6 +43,8 @@
     this.rootnode = node;
     this.element.attr("data-root", node.id());
     node.element.attr("data-child-role", "root");
+    node.element.removeAttr("data-parent data-binchildrole data-child-pos");
+    if (oldroot) { oldroot.element.removeAttr("data-child-role"); }
     return [oldroot];
   });
   treeproto.root = function(newRoot, options) {


### PR DESCRIPTION
Removes the attributes of the new root node that are not supposed to be in a root node. Respectively, it removes the attribute data-child-role, which is only used by root nodes, from the old root. This should probably have been a part of #109.
