### PR TITLE
Fixed null node issue

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -400,6 +400,7 @@
           // child exists
           if (!oChild || oChild.value() === "jsavnull") { // ..but no other child
             if (opts.hide) { child.hide(); }
+            if (oChild) { oChild.hide(); }
             self._setchildnodes([]);
           } else { // other child exists
             // create a null node and set it as other child


### PR DESCRIPTION
Fixed issue with binary tree, where a null node could overlap another node.

![tree2](https://f.cloud.github.com/assets/3896558/947129/c1e64e32-0349-11e3-9e97-4294959d6c8f.png)

In the picture the null nodes have been colored pink. The exercise is BST delete, and the next node to be deleted is 28, and it's hidden behind a null node, which prevents clicking on it. The null node is in front of the other node, because I have previously deleted the left child of 23. 23 doesn't have children anymore, but the null node is just left there.

I know you are trying to get rid of the null nodes, but in case you are busy and it takes a while, I think this fix should be merged.
