### PR TITLE
Added tag support for code

### DIFF
--- a/src/code.js
+++ b/src/code.js
@@ -516,7 +516,7 @@
         $prev = this.element.find("li.jsavpreviousline"),
         previndex = this.element.find("li.jsavcodeline").index($prev);
     if (typeof index === "string") {
-      if (this.options.tags && this.options.tags[index]) {
+      if (this.options.tags && typeof this.options.tags[index] !== "undefined") {
         index = this.options.tags[index];
       } else {
         index = -1;


### PR DESCRIPTION
Tags defined in the options when initializing the code object can now be used instead of indices.

Example:

```
var code = av.code("line 1\n" + "line 2\n" + "line 3", {tags: {line1: 0, line2: 1, line3: 2 }});

code.setCurrentLine("line1");
code.setCurrentLine("line2");
code.setCurrentLine("line3");
code.highlight("line1");
```
