### PR TITLE
Fixed undo for the final step grader

### DIFF
--- a/src/exercise.js
+++ b/src/exercise.js
@@ -373,7 +373,8 @@
     this.jsav.backward(); // the empty new step
     this.jsav.backward(); // the new graded step
     // undo until the previous graded step
-    if ((this.options.grader === "default" || this.options.grader === "finder") && this.jsav.backward(gradeStepFilterFunction)) {
+    var undoGraders = ["default", "finder", "finalStep"];
+    if ((undoGraders.indexOf(this.options.grader) !== -1 ) && this.jsav.backward(gradeStepFilterFunction)) {
       // if such step was found, redo it
       this.jsav.forward();
       this.jsav.step();


### PR DESCRIPTION
There's no undo button for the continuous grader, so is there a reason to check if the selected grader is not "default-continuous", or is this some old code which remains? If there is a reason maybe there should be an option for undo or continuous grading.
