### PR TITLE
Removed margins from jsavedgelabel

### DIFF
--- a/css/JSAV.css
+++ b/css/JSAV.css
@@ -488,6 +488,7 @@ a.jsavdialogclose {
   z-index: 700;
   position: absolute;
   display: inline-block;
+  margin: 0;
 }
 
 /******** LINKED LIST STRUCTURE ******/


### PR DESCRIPTION
Removed margins from jsavedgelabel. The margins breaked positioning of edge labels.
See: [Common Trie Exercise](http://algoviz.org/OpenDSA/dev/OpenDSA/AV/Development/commonTriePRO.html)
