### PR TITLE
Cleaner design for Settings/Model Answer Dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#JSAV ![Travis CI Build status](https://travis-ci.org/vkaravir/JSAV.svg?branch=master)
+#JSAV [![Travis CI Build Status](https://travis-ci.org/vkaravir/JSAV.svg?branch=master)](https://travis-ci.org/vkaravir/JSAV)
 This is the JSAV development library for creating Algorithm
 Visualizations in JavaScript.
 

--- a/css/JSAV.css
+++ b/css/JSAV.css
@@ -338,42 +338,67 @@
 
 /**** STYLING THE DIALOG ****/
 .jsavdialog {
-  border: 1px solid black;
+  border: 1px solid #aaa;
   background-color: #fff;
   z-index: 1000;
   position: absolute;
   top: 0; 
   left: 0;
-  -moz-border-radius: 6px;
-  -ms-border-radius: 6px;
-  -o-border-radius: 6px;
-  -webkit-border-radius: 6px;
-  border-radius: 6px;
+  box-shadow: 0 0 15px rgba(0,0,0,0.8);
 }
 .jsavmodal {
   z-index: 999;
   background-color: rgb(120, 120, 120);
   background-color: rgba(0, 0, 0, 0.2);
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
+  bottom: 0;
+  right: 0;
 }
 .jsavdialog h2 {
   background-color: #eee;
-  border-bottom: 1px dashed black;
   color: black;
+  font-family: Helvetica, Arial;
   font-size: 1.5em;
   font-weight: bold;
   margin: 0;
-  padding: 5px;
-  -moz-border-radius: 6px 6px 0 0;
-  -ms-border-radius: 6px 6px 0 0;
-  -o-border-radius: 6px 6px 0 0;
-  -webkit-border-radius: 6px 6px 0 0;
-  border-radius: 6px 6px 0 0;
+  padding: 7px 15px;
+  cursor: -moz-grab;
+  cursor: -webkit-grab;
+  cursor: grab;
 }
+.jsavdialog.ui-draggable-dragging, .jsavdialog.ui-draggable-dragging h2 {
+  cursor: -moz-grabbing;
+  cursor: -webkit-grabbing;
+  cursor: grabbing;
+}
+a.jsavdialogclose {
+  border: 1px solid #777;
+  -ms-border-radius: 20px;
+  -webkit-border-radius: 20px;
+  -moz-border-radius: 20px;
+  -o-border-radius: 20px;
+  border-radius: 20px;
+  color: #777;
+  float: right;
+  font-family: monospace;
+  font-size: 30px;
+  font-weight: normal;
+  height: 20px;
+  padding: 3px;
+  text-align: center;
+  text-decoration: none;
+  width: 20px;
+  line-height: 22px;
+}
+a.jsavdialogclose:hover {
+  background-color: #ccc;
+}
+
 .jsavsettings {
   padding: 15px;
+  font-family: Helvetica, Arial
 }
 a.jsavsettings {
   background-image: url(images/settings.png);
@@ -439,26 +464,6 @@ a.jsavsettings:hover {
 /* move the (model answer) dialog outside of view when preparing it */
 .jsavdialog.jsavmodelpreparing {
   left: -110% !important;
-}
-a.jsavdialogclose {
-  background-color: #AAA;
-  border: 2px solid white;
-  -ms-border-radius: 20px;
-  -webkit-border-radius: 20px;
-  -moz-border-radius: 20px;
-  -o-border-radius: 20px;
-  border-radius: 20px;
-  color: white;
-  float: right;
-  font-family: monospace;
-  font-size: 20px;
-  font-weight: normal;
-  height: 20px;
-  padding: 3px;
-  text-align: center;
-  text-decoration: none;
-  width: 20px;
-  line-height: 1;
 }
 
 .jsavexercisecontrols {

--- a/src/utils.js
+++ b/src/utils.js
@@ -192,12 +192,11 @@
     //  - dialogBase
     //  - dialogRootElement
     options = $.extend({}, {modal: true, closeOnClick: true}, options);
-    var d = {
-      },
-      modal = options.modal,
-      $dialog = $(options.dialogBase || dialogBase),
-      i, l, attr,
-      attrOptions = ["width", "height", "minWidth", "minHeight", "maxWidth", "maxHeight"];
+    var d = {},
+        modal = options.modal,
+        $dialog = $(options.dialogBase || dialogBase),
+        i, l, attr,
+        attrOptions = ["width", "height", "minWidth", "minHeight", "maxWidth", "maxHeight"];
     if (typeof html === "string") {
       $dialog.html(html);
     } else if ($.isFunction(html)) {
@@ -206,7 +205,7 @@
       $dialog.append(html); // jquery or dom element
     }
     if ("title" in options) {
-      $dialog.prepend("<h2>" + options.title + "<a href='#' class='jsavdialogclose'>X</a></h2>");
+      $dialog.prepend("<h2>" + options.title + "<a href='#' class='jsavdialogclose'>&times;</a></h2>");
     }
     if ("dialogClass" in options) {
       $dialog.addClass(options.dialogClass);
@@ -242,7 +241,6 @@
     };
     if (modal) {
       $modalElem = $modalElem || $('<div class="jsavmodal" />');
-      $modalElem.css({width: docWidth, height: docHeight});
       $modalElem.appendTo($("body"));
       if (options.closeOnClick) {
         $modalElem.click(close);
@@ -255,7 +253,7 @@
       $dialog.append(closeButton);
     }
 
-    var $dial = $dialog.appendTo(options.dialogRootElement || $("body")).add($modalElem);
+    var $dial = $dialog.appendTo(options.dialogRootElement || $("body"));
     $dial.draggable();
     var center = function() {
       $dialog.css({


### PR DESCRIPTION
- Cleaner design for settings/model answer windows (JSAV dialog)
- jsavmodal is no longer draggable
- Grab/Grabbing cursor for JSAV dialog
- Added link to Travis build status image

![screenshot3](https://cloud.githubusercontent.com/assets/3896558/6551733/187c21f2-c646-11e4-8b51-f084f3de41eb.jpg)
![screenshot4](https://cloud.githubusercontent.com/assets/3896558/6551734/187d7b42-c646-11e4-8055-76942e16a926.jpg)