### PR TITLE
Changed the way oversized trees are rendered

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -766,7 +766,7 @@
         return 0;
       }
       var containerWidth = $(tree.jsav.canvas).width();
-      return (containerWidth - width)/2 - tree.position().left;
+      return Math.max(0, (containerWidth - width)/2) - tree.position().left;
     };
 
     var treeDims = { width: maxX - minX, height: maxY - minY },


### PR DESCRIPTION
Changed the way oversized trees are rendered to make it possible to enable scrolling.

See examples of a oversized trees below.

**Current layout function:**
![treescrollorig](https://cloud.githubusercontent.com/assets/3896558/6781446/65996540-d176-11e4-95f0-1ea2f4f4767f.jpg)
*The tree's left value will become negative to keep the tree centered. Thus, both sides of the tree will disappear.*

**New layout function:**
![treescrollnowrapper](https://cloud.githubusercontent.com/assets/3896558/6781460/8159b212-d176-11e4-81dc-1c1ddf2ab77d.jpg)
*With the new layout the tree's left value will never be negative.*

**New layout function with scroll bars:**
![treescroll1](https://cloud.githubusercontent.com/assets/3896558/6781469/a43a9f1c-d176-11e4-9c22-500ce455bdc1.jpg)
![treescroll2](https://cloud.githubusercontent.com/assets/3896558/6781470/a441c562-d176-11e4-96f6-8724e416d4ec.jpg)
*Since, the left value isn't negative and the canvas has resized properly, we can show a scroll bar, so that the user can check the whole tree.*

The scroll bars were made by wrapping the `jsavcanvas` inside a simple div.
```CSS
.scroll-wrapper {
  width: 100%;
  overflow-x: scroll;
}
```