### PR TITLE
Fixed jsav.clear()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -64,7 +64,7 @@
       this.container = $(this.options.element);
     }
 
-    var initialHTML = this.container.clone().wrap("<p/>").parent().html();
+    var initialHTML = this.container.html();
     this._initialHTML = initialHTML;
 
     this.container.addClass("jsavcontainer");


### PR DESCRIPTION
`jsav._initialHTML` should not contain the HTML tags of the (wrapping) JSAV container. If it does, a new JSAV containers will be inserted in the current JSAV container when calling `jsav.clear()` (see screenshot below).

![clear](https://cloud.githubusercontent.com/assets/3896558/6894352/ac7056ba-d6dd-11e4-8a48-abb2abb9388d.jpg)
*Can be replicated by calling `av.clear()` in simple-exercise.html*