### PR TITLE
Fixed graph node sort function

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -39,7 +39,7 @@
   };
   // a helper function to sort an array of nodes based on the node value
   Graph._nodeSortFunction = function(a, b) {
-    return a.value() < b.value();
+    return a.value() - b.value();
   };
 
   JSAV.utils.extend(Graph, JSAV._types.ds.JSAVDataStructure);


### PR DESCRIPTION
The function that is handed to Array.prototype.sort() should be an integer value.

Also, why is this function given as a parameter in `this.nodes(Graph._nodeSortFunction)`? Should it be `this.nodes().sort(Graph._nodeSortFunction)` instead?

- [graph.js:246](https://github.com/vkaravir/JSAV/blob/master/src/graph.js#L246)
- [graph.js:258](https://github.com/vkaravir/JSAV/blob/master/src/graph.js#L258)
- [graph.js:279](https://github.com/vkaravir/JSAV/blob/master/src/graph.js#L279)
- [graph.js:313](https://github.com/vkaravir/JSAV/blob/master/src/graph.js#L313)