### PR TITLE
Change dialog position for slideshows to be relative to #settings element, Instead of page scroll bar.

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -68,7 +68,7 @@
       return $elem;
     };
   };
-  
+
   /* Creates an input component to be used in the settings panel. varname should be unique
     within the document. Options can specify the label of the component, in which case
     a label element is created. Option value specifies the default value of the element.
@@ -91,7 +91,7 @@
     }
     return $('<div class="jsavrow"/>').append(label).append(input);
   };
-  
+
   /* Creates a select component to be used in the settings panel. varname should be unique
     within the document. Options can specify the label of the component, in which case
     a label element is created. Option value specifies the default value of the element.
@@ -120,28 +120,28 @@
     }
     return $('<div class="jsavrow"/>').append(label).append(select);
   };
-  
+
   var Settings = function(elem) {
       this.components = [];
       this.add(speedSetting(this));
-      
+
       var that = this;
       if (elem) {
         $(elem).click(function(e) {
           e.preventDefault();
-          that.show();
+          that.show(e);
         });
       }
     },
     sproto = Settings.prototype;
-  sproto.show = function() {
+  sproto.show = function(event) {
     var $cont = $("<div class='jsavsettings'></div>");
     for (var i = 0; i < this.components.length; i++) {
       $cont.append(this.components[i]);
     }
     // append the JSAV version to the settings dialog
     $cont.append("<span class='jsavversion'>" + JSAV.version() + "</span>");
-    
+
     var translate;
     if (this.jsav) {
       translate = this.jsav._translate;
@@ -156,7 +156,7 @@
       translate = JSAV.utils.getInterpreter(JSAV._translations, lang);
     }
     var title = translate("settings");
-    this.dialog = JSAV.utils.dialog($cont, {title: title});
+    this.dialog = JSAV.utils.dialog($cont, {title: title}, event);
   };
   sproto.close = function() {
     if (this.dialog) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -176,11 +176,11 @@
       $("body").trigger("jsav-log-event", [eventData]);
     }
   };
-  
+
   var dialogBase = '<div class="jsavdialog"></div>',
     $modalElem = null;
-  
-  u.dialog = function(html, options) {
+
+  u.dialog = function(html, options, event) {
     // options supported :
     //  - modal (default true)
     //  - width (and min/maxWidth)
@@ -255,21 +255,37 @@
 
     var $dial = $dialog.appendTo(options.dialogRootElement || $("body"));
     $dial.draggable();
-    var center = function() {
-      $dialog.css({
-        top: Math.max(scrollTop + (winHeight - $dialog.outerHeight())/2, 0),
-        left: scrollLeft + (winWidth - $dialog.outerWidth())/2
-      });
+    var event = event || false;
+    var center = function(event) {
+      if (event) {
+        var $target = $(event.target),
+          pos = $target.offset(),
+          eWidth = $target.outerWidth(),
+          mWidth = $dialog.outerWidth(),
+          left = (pos.left + eWidth - mWidth) + "px",
+          top = 3 + pos.top + "px";
+          $dialog.css({
+            position: 'absolute',
+            zIndex: 5000,
+            left: left,
+            top: top
+          });
+      } else {
+        $dialog.css({
+          top: Math.max(scrollTop + (winHeight - $dialog.outerHeight())/2, 0),
+          left: scrollLeft + (winWidth - $dialog.outerWidth())/2
+        });
+      }
     };
-    center();
+    center(event);
     $dial.show = function() {
-      center();
+      center(event);
       $dial.fadeIn();
     };
     $dial.close = close;
     return $dial;
   };
-  
+
   u.value2type = function(val, valtype) {
     if (valtype === "number") {
       return Number(val);
@@ -284,7 +300,7 @@
       return val;
     }
   };
-  
+
   var dummyTestFunction = function(dataArr) { return true; };
   u.rand = {
     random: Math.random,
@@ -371,7 +387,7 @@
   u.getInterpreter = function (langJSON, selectedLanguage) {
     var trans;
 
-    // get the translation from the given location or object 
+    // get the translation from the given location or object
     if (typeof langJSON === "string") {
       // assume langJSON is a url
       if (langJSON.indexOf("{lang}") !== -1) {
@@ -420,7 +436,7 @@
   };
 
   /* Replaces the labels (surrounded by curly brackets) in a string with a value
-   * 
+   *
    * For instance if the string is "The value of x is {x}" and the object
    * containing the replacements for the tag is {x: 7}, this function will
    * return the string "The value of x is 7"
@@ -682,7 +698,7 @@ mixkey(math.random(), pool);
 /*!
  End seedrandom.js
  */
- 
+
   var _helpers = {};
   u._helpers = _helpers;
   var JSAV_CLASS_NAMES = ["jsavarray", "jsavhorizontalarray", "jsavverticalarray",

--- a/src/utils.js
+++ b/src/utils.js
@@ -258,15 +258,34 @@
     var event = event || false;
     var center = function(event) {
       if (event) {
-        var $target = $(event.target),
-          pos = $target.offset(),
+        var parents;
+
+        // get .jsavcontainer element for slideshow
+        var $target = $(event.target).closest('.jsavcontainer');
+
+        // get .avcontainer or .jsavcontainer element for AV
+        if ($target.length === 0){
+          parents = $(event.target).parents();
+
+          parents.each(function(index, value){
+            var targetElem = $(value).find('.avcontainer, .jsavcontainer');
+            if (targetElem.length > 0){
+              $target = $(targetElem);
+              return false;
+            }
+          });
+        }
+
+        var pos = $target.offset(),
           eWidth = $target.outerWidth(),
-          mWidth = $dialog.outerWidth(),
-          left = (pos.left + eWidth - mWidth) + "px",
-          top = 3 + pos.top + "px";
+          dWidth = $dialog.outerWidth(),
+          eHeight = $target.outerHeight(),
+          dHeight = $dialog.outerHeight(),
+          left = (pos.left + eWidth/2 - dWidth/2) + "px",
+          top = (pos.top + eHeight/2 - dHeight/2) + "px";
           $dialog.css({
             position: 'absolute',
-            zIndex: 5000,
+            zIndex: 1000,
             left: left,
             top: top
           });


### PR DESCRIPTION
Hi Ville,

  OpenDSA modules are iframed in canvas LMS, the iframed module doesn't have scroll bar. Because JSAV position slideshow settings dialog with respect to the page scroll bar, the dialog will always appear in the middle of canvas iframe. So this PR change the way settings dialog positioned and make it reative to #settings element instead of page scroll bar.

This is related to https://github.com/OpenDSA/OpenDSA/issues/309

Thanks
~Hosam