### PR TITLE
Update jQuery to 2.1.4 and jQueryUI to 1.11.4 (latest versions).

### DIFF
--- a/examples/allStructures.html
+++ b/examples/allStructures.html
@@ -35,10 +35,8 @@
 <h1>Example of All Data Structures in JSAV</h1>
 <div id="av">
 </div>
-<script
-        src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js">
-</script>
-<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
 <script src="../lib/jquery.transit.js"></script>
 <script src="../lib/raphael.js"></script>
 <script src="../build/JSAV.js"></script>

--- a/examples/binarytree.html
+++ b/examples/binarytree.html
@@ -30,10 +30,8 @@
     <div id="av">
       <div class="jsavcontrols"></div><span class="jsavcounter"></span>
     </div>
-    <script
-       src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js">
-    </script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
     <script src="../lib/jquery.transit.js"></script>
     <script src="../lib/raphael.js"></script>
     <script src="../build/JSAV.js"></script>

--- a/examples/findmax.html
+++ b/examples/findmax.html
@@ -23,12 +23,8 @@
   <div class="jsavcanvas"></div>
   <p class="jsavoutput jsavline"></p>
 </div>
-<script
-   src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js">
-</script>
-<script
-   src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js">
-</script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
 <script src="../lib/jquery.transit.js"></script>
 <script src="../lib/raphael.js"></script>
 <script src="../build/JSAV-min.js"></script>

--- a/examples/graph.html
+++ b/examples/graph.html
@@ -36,10 +36,8 @@
       <div class="jsavcontrols"></div><span class="jsavcounter"></span>
       <p class="jsavoutput jsavline"></p>
     </div>
-    <script
-       src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js">
-    </script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
     <script src="../lib/jquery.transit.js"></script>
     <script src="../lib/raphael.js"></script>
     <script src="../lib/dagre.min.js"></script>

--- a/examples/list.html
+++ b/examples/list.html
@@ -23,10 +23,8 @@
       <p class="jsavoutput jsavline"></p>
       <div class="jsavcanvas"></div>
     </div>
-    <script
-       src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js">
-    </script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
     <script src="../lib/jquery.transit.js"></script>
     <script src="../lib/raphael.js"></script>
     <script src="../build/JSAV.js"></script>

--- a/examples/manual-graph.html
+++ b/examples/manual-graph.html
@@ -10,10 +10,8 @@
       <div class="jsavcontrols"></div><span class="jsavcounter"></span>
       <p class="jsavoutput jsavline"></p>
     </div>
-    <script
-       src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js">
-    </script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
     <script src="../lib/jquery.transit.js"></script>
     <script src="../lib/raphael.js"></script>
     <script src="../build/JSAV.js"></script>

--- a/examples/pointers.html
+++ b/examples/pointers.html
@@ -30,12 +30,8 @@
     <p class="jsavoutput jsavline"></p>
     <div class="jsavcanvas"></div>
   </div>
-  <style>
-  </style>
-    <script
-       src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js">
-    </script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
     <script src="../lib/jquery.transit.js"></script>
     <script src="../lib/raphael.js"></script>
     <script src="../build/JSAV.js"></script>

--- a/examples/pseudocode.html
+++ b/examples/pseudocode.html
@@ -20,10 +20,8 @@
       <div class="jsavcontrols"></div><span class="jsavcounter"></span>
       <p class="jsavoutput jsavline"></p>
     </div>
-    <script
-       src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js">
-    </script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
     <script src="../lib/jquery.transit.js"></script>
     <script src="../lib/raphael.js"></script>
     <script src="../build/JSAV.js"></script>

--- a/examples/simple-exercise.html
+++ b/examples/simple-exercise.html
@@ -34,10 +34,8 @@
     <p class="jsavoutput jsavline"></p>
   </div>
 
-    <script
-       src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js">
-    </script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
     <script src="../lib/jquery.transit.js"></script>
     <script src="../build/JSAV.js"></script>
 

--- a/examples/slideshow.html
+++ b/examples/slideshow.html
@@ -24,10 +24,8 @@
   </div>
   <style>
   </style>
-    <script
-       src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js">
-    </script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
     <script src="../lib/jquery.transit.js"></script>
     <script src="../lib/raphael.js"></script>
     <script src="../build/JSAV.js"></script>

--- a/examples/sounds/sounds.html
+++ b/examples/sounds/sounds.html
@@ -23,10 +23,8 @@
   <p class="jsavcontrols"></p>
   <p class="jsavoutput jsavline"></p>
 </div>
-<script
-        src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js">
-</script>
-<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
 <script src="../../lib/jquery.transit.js"></script>
 <script src="../../lib/raphael.js"></script>
 <script src="../../build/JSAV.js"></script>

--- a/examples/sudoku.html
+++ b/examples/sudoku.html
@@ -40,8 +40,8 @@
   .jsavarray:nth-of-type(3n-2) li { border-top: 2px solid black !important;}
   .jsavarray:nth-of-type(9) li { border-bottom: 2px solid black !important;}
   </style>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
     <script src="../lib/jquery.transit.js"></script>
     <script src="../lib/raphael.js"></script>
     <script src="../build/JSAV-min.js"></script>

--- a/src/exercise.js
+++ b/src/exercise.js
@@ -66,7 +66,7 @@
       } else {
         cont.append($reset, $model, $action);
       }
-      $action.position({of: cont.children().last(), at: "right center", my: "left center", offset: "5 -2"});
+      $action.position({of: cont.children().last(), at: "right center", my: "left+5 center-2"});
     }
     // if feedbacktype can be selected, add settings for it
     if (this.options.feedbackSelectable) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -860,6 +860,30 @@ mixkey(math.random(), pool);
     return true;
   };
 
+  // logic for handling anchors like in jQueryUI code
+  var rhorizontal = /left|center|right/,
+      rvertical = /top|center|bottom/;
+  var combineAnchorAndOffsets = function(anchor, offsetLeft, offsetTop) {
+    // for new jQueryUI, we need to combine the offsets into the anchor, and
+    // that's what this function does
+    var pos = ( anchor || "" ).split( " " );
+
+    // if we ony have one anchor, figure out which one it's
+    // default to center for the other
+    if ( pos.length === 1 ) {
+      pos = rhorizontal.test( pos[ 0 ] ) ?
+        pos.concat( [ "center" ] ) :
+        rvertical.test( pos[ 0 ] ) ?
+          [ "center" ].concat( pos ) :
+          [ "center", "center" ];
+    }
+    pos[ 0 ] = rhorizontal.test( pos[ 0 ] ) ? pos[ 0 ] : "center";
+    pos[ 1 ] = rvertical.test( pos[ 1 ] ) ? pos[ 1 ] : "center";
+
+    return pos[0] + (offsetLeft >= 0 ? '+' + offsetLeft : offsetLeft) +
+          ' ' + pos[1] + (offsetTop >= 0 ? '+' + offsetTop : offsetTop);
+  };
+
   // position the given object relative to relElem, taking into account offsets and anchors
   // the move is animated
   var animateToNewRelativePosition = function(jsavobj, relElem, offsetLeft, offsetTop, anchor, myAnchor) {
@@ -867,10 +891,9 @@ mixkey(math.random(), pool);
         elemCurPos = el.position();
 
     // use jqueryui to position the el relative to the relElem
-    el.position({my: myAnchor,
+    el.position({my: combineAnchorAndOffsets(myAnchor, offsetLeft, offsetTop),
       at: anchor,
       of: relElem,
-      offset: offsetLeft + " " + offsetTop,
       collision: "none"});
     var elemPos = el.position();
     var elemLeft = elemPos.left;
@@ -970,10 +993,9 @@ mixkey(math.random(), pool);
         options.callback(move.left, move.top);
       }
     } else { // set the initial position to the current position (to prevent unnecessary animations)
-      el.position({my: myAnchor,
+      el.position({my: combineAnchorAndOffsets(myAnchor, offsetLeft, offsetTop),
                    at: anchor,
                    of: relElem,
-                   offset: offsetLeft + " " + offsetTop,
                    collision: "none"});
     }
     if (follow) { // if the jsavobj should move along with the target, register it to do so

--- a/test/index.html
+++ b/test/index.html
@@ -6,8 +6,8 @@
     <link rel="stylesheet" media="screen" href="utils/qunit.css" />
     <link rel="stylesheet" href="../css/JSAV.css" media="screen" />
     <!-- Library Includes -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
     <script src="../lib/jquery.transit.js"></script>
     <script src="../lib/raphael.js"></script>
 


### PR DESCRIPTION
NOTE: This breaks compatibility with older versions for pointer positioning.
However, since JSAV has never supported older browsers (at least not officially),
it makes sense to upgrade. Also, the upgrade is necessary in order for JSAV to work
with the latest version of the Khan Academy exercise framework.