### PR TITLE
Check that localStorage is defined before using in if condition to prevent bug on edge

### DIFF
--- a/src/anim.js
+++ b/src/anim.js
@@ -300,7 +300,7 @@
     return true;
   }
   JSAV.anim = anim;
-  if (localStorage) { // try to fetch a stored setting for speed from localStorage
+  if (typeof localStorage !== 'undefined' && localStorage) { // try to fetch a stored setting for speed from localStorage
     var spd = localStorage.getItem("jsav-speed");
     if (spd) { // if we have a value, it is a string (from localStorage)
       spd = parseInt(spd, 10);

--- a/src/settings.js
+++ b/src/settings.js
@@ -47,7 +47,7 @@
         JSAV.ext.SPEED = speed;
         //trigger speed change event to update all AVs on the page
         $(document).trigger("jsav-speed-change", speed);
-        if (localStorage) {
+        if (typeof localStorage !== 'undefined' && localStorage) {
           localStorage.setItem("jsav-speed", speed);
         }
       };


### PR DESCRIPTION
Trying to access `localStorage` in if-condition on edge causes an exception to be thrown. This change updates JSAV to do a `typeof localStorage !== 'undefined' && localStorage` which doesn't cause the exception.